### PR TITLE
Made compatible with altv 10.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vs
 GameEntityScript/obj/*
+dist/*

--- a/GameEntityScript/GameEntityResource.cs
+++ b/GameEntityScript/GameEntityResource.cs
@@ -13,8 +13,8 @@ namespace GameEntityScript
         {
             AltEntitySync.Init(
                 1,
-                100,
-                true,
+                (threaId) => 100,
+                (threadId) => true,
                 (threadCount, repository) => new ServerEventNetworkLayer(threadCount, repository),
                 (entity, threadCount) => (entity.Id % threadCount),
                 (entityId, entityType, threadCount) => (entityId % threadCount),

--- a/GameEntityScript/GameEntityScript.csproj
+++ b/GameEntityScript/GameEntityScript.csproj
@@ -1,21 +1,22 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>D:\Change\To\Your\Path</OutputPath>
+    <OutputPath>$(SolutionDir)dist</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>D:\Change\To\Your\Path</OutputPath>
+    <OutputPath>$(SolutionDir)dist</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AltV.Net" Version="1.48.3" />
-    <PackageReference Include="AltV.Net.EntitySync" Version="1.7.0-dev-preview" />
-    <PackageReference Include="AltV.Net.EntitySync.ServerEvent" Version="1.7.0-dev-preview" />
+    <PackageReference Include="AltV.Net" Version="10.0.3" />
+    <PackageReference Include="AltV.Net.EntitySync" Version="1.18.0" />
+    <PackageReference Include="AltV.Net.EntitySync.ServerEvent" Version="10.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Changed targetting framework to .NET 6.0 (.Net Core 3.1 before) as required to work with the newest version's of the EntitySync Nuget Packages.
Updated NuGet Packages accordingly to the latest greatest.
Changed AltEntitySync.Init call accordingly to meet the new method signature
Output will be built into a dist directory beneath the Solution directory.
Increased version to 1.1.0